### PR TITLE
Fix failing activity creation [Wilkins]

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,7 +3,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="LOCAL" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="D:\DEV\IDE\Android\Android Studio\gradle\gradle-4.1" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/SEProject.iml" filepath="$PROJECT_DIR$/SEProject.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/github.iml" filepath="$PROJECT_DIR$/github.iml" />
     </modules>
   </component>
 </project>


### PR DESCRIPTION
I've asked Lee and Nick to review in Windows and macOS, respectively.

If you can both build and create a new activity, we'll say that https://github.com/NicholasBarreyre/SEProject/issues/17 is fixed?

Going forward, we should stick to having SEProject as the root folder for the project as well.